### PR TITLE
Oddsmonkey screener, Exclusion Requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ vip.json
 clients.txt
 src/data.json
 getClientDetails.py
+src/gmailcreds.json
+token.json
+retest.py
+yes.py

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ src/gmailcreds.json
 token.json
 retest.py
 yes.py
+External Sources.PNG


### PR DESCRIPTION
Pull down Oddsmonkey Notification emails from Gmail API, Parse to retrieve selections we have live on the site with higher 'back' odds compared to exchange 'lay' odds. 
If a client backs one of these selections above the lay price, it will kick out a message in the feed. Additionally create a report on the entire day, kicking out users who've backed Oddsmonkey selections above the lay price at the time. 

Pull down 'exclusion requests' from Gmail API, parse to retrieve client account closure requests. Staff can handle the request from inside the program in a few clicks, instead of a 10 step process which can be time consuming. 